### PR TITLE
Handle  SPH_DOUBLE=ON + CAN_LOAD_TIPSY=ON  in CMakeLists.txt

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,6 +49,10 @@ if(NOT STRIDED_SCALARS AND CAN_LOAD_TIPSY)
     message(FATAL_ERROR "STRIDED_SCALARS=${STRIDED_SCALARS} (SOA) and CAN_LOAD_TIPSY=${CAN_LOAD_TIPSY} is not supported")
 endif()
 
+if(SPH_DOUBLE AND CAN_LOAD_TIPSY)
+    message(FATAL_ERROR "SPH_DOUBLE=${SPH_DOUBLE} and CAN_LOAD_TIPSY=${CAN_LOAD_TIPSY} cannot both be turned ON")
+endif()
+
 if(CAN_LOAD_H5Part)
 find_package(HDF5 REQUIRED)
 endif()

--- a/src/VTKmAdaptor.h
+++ b/src/VTKmAdaptor.h
@@ -107,7 +107,11 @@ void Initialize(int argc, char* argv[], sph::ParticlesData<T> *sim)
                                              sim->n * sim->NbofScalarfields,
                                              vtkm::CopyFlag::Off);
   sim->scalarsAOS.clear(); // just to make sure we're going to the device
+#ifdef SPH_DOUBLE
+  sim->scalarsAOS = std::vector<sph::ParticlesData<double>::tipsySph>();
+#else
   sim->scalarsAOS = std::vector<sph::ParticlesData<float>::tipsySph>();
+#endif
 #else
   std::cout << "using host-allocated data\n";
 // base of the AOS struct{}. every field will be offset from that base

--- a/src/VTKmAdaptor.h
+++ b/src/VTKmAdaptor.h
@@ -107,11 +107,7 @@ void Initialize(int argc, char* argv[], sph::ParticlesData<T> *sim)
                                              sim->n * sim->NbofScalarfields,
                                              vtkm::CopyFlag::Off);
   sim->scalarsAOS.clear(); // just to make sure we're going to the device
-#ifdef SPH_DOUBLE
-  sim->scalarsAOS = std::vector<sph::ParticlesData<double>::tipsySph>();
-#else
   sim->scalarsAOS = std::vector<sph::ParticlesData<float>::tipsySph>();
-#endif
 #else
   std::cout << "using host-allocated data\n";
 // base of the AOS struct{}. every field will be offset from that base


### PR DESCRIPTION
```
 -DSTRIDED_SCALARS=ON \
    -DSPH_DOUBLE=ON \
    -DCAN_LOAD_TIPSY=ON \
    -DCAN_LOAD_H5Part=OFF \
```

fails to build with:
```
[ 50%] Building CUDA object CMakeFiles/dummysph_vtkm.dir/Driver.cu.o
src/VTKmAdaptor.h(110): error: no operator "=" matches these operands
            operand types are: std::vector<sph::ParticlesData<double>::tipsySph, std::allocator<sph::ParticlesData<double>::tipsySph>> = std::vector<sph::ParticlesData<float>::tipsySph, std::allocator<sph::ParticlesData<float>::tipsySph>>
    sim->scalarsAOS = std::vector<sph::ParticlesData<float>::tipsySph>();
```

Adding code to allow compilation.